### PR TITLE
Minor cleanup

### DIFF
--- a/PortfolioLedger/Engine/LedgerEngine.swift
+++ b/PortfolioLedger/Engine/LedgerEngine.swift
@@ -565,7 +565,6 @@ extension LedgerEngine {
         let linkGroupId = UUID()
         let contractQuantity = optionTransaction.quantity
         let shareQuantity = contractQuantity * Decimal(multiplier)
-        let premiumPerShare = optionTransaction.price / Decimal(multiplier)
 
         // Close the option position (consumed by assignment)
         let optionClose = Transaction(
@@ -581,26 +580,17 @@ extension LedgerEngine {
             flags: TransactionFlags(consumedByAssignment: true)
         )
 
-        // Generate equity trade at effective price
-        let effectivePrice: Decimal
-        let equityAction: TransactionAction
-
-        if callPut == .put {
-            // Put assignment = we buy stock at strike minus premium received
-            effectivePrice = strike - premiumPerShare
-            equityAction = .buy
-        } else {
-            // Call assignment = we sell stock at strike plus premium received
-            effectivePrice = strike + premiumPerShare
-            equityAction = .sell
-        }
+        // Equity trades at the strike price. The option premium is already recorded
+        // as P/L when the option was opened (cash basis), so including it here would
+        // double-count it.
+        let equityAction: TransactionAction = (callPut == .put) ? .buy : .sell
 
         let equityTrade = Transaction(
             instrumentId: equityInstrument.id,
             timestamp: assignmentDate,
             action: equityAction,
             quantity: shareQuantity,
-            price: effectivePrice,
+            price: strike,
             fees: 0,
             notes: "Option assignment",
             tags: ["assignment"],

--- a/PortfolioLedger/Services/DataStore.swift
+++ b/PortfolioLedger/Services/DataStore.swift
@@ -44,6 +44,34 @@ class DataStore: ObservableObject {
         saveData()
     }
 
+    func deleteTransactions(_ toDelete: [Transaction]) {
+        let ids = Set(toDelete.map(\.id))
+        transactions.removeAll { ids.contains($0.id) }
+        recomputeLedger()
+        saveData()
+    }
+
+    /// Returns all transactions linked to an option assignment for `txns`.
+    /// Finds transactions sharing the same linkGroupId, then expands to include
+    /// all transactions for those instruments (e.g. the STO for an option close).
+    func linkedAssignmentTransactions(for txns: [Transaction]) -> [Transaction] {
+        let linkIds = Set(txns.compactMap(\.linkGroupId))
+        guard !linkIds.isEmpty else { return [] }
+        let ownIds = Set(txns.map(\.id))
+
+        // Find directly linked transactions (BTC/equity leg via linkGroupId)
+        let directlyLinked = transactions.filter {
+            guard let lid = $0.linkGroupId else { return false }
+            return linkIds.contains(lid) && !ownIds.contains($0.id)
+        }
+
+        // Expand to all transactions for those instruments (picks up the STO, etc.)
+        let linkedInstrumentIds = Set(directlyLinked.map(\.instrumentId))
+        return transactions.filter {
+            linkedInstrumentIds.contains($0.instrumentId) && !ownIds.contains($0.id)
+        }
+    }
+
     // MARK: - Ledger Computation
 
     private func recomputeLedger() {

--- a/PortfolioLedger/Views/DashboardView.swift
+++ b/PortfolioLedger/Views/DashboardView.swift
@@ -144,9 +144,10 @@ struct PositionRowCompact: View {
                     .foregroundColor(.secondary)
             }
             Spacer()
-            Text("$\(formatPrice(position.costBasis))")
+            Text("\(position.costBasis <= 0 ? "+" : "-")$\(formatPrice(abs(position.costBasis)))")
                 .font(.subheadline)
                 .fontWeight(.medium)
+                .foregroundColor(position.costBasis <= 0 ? .green : .red)
         }
         .padding(.vertical, 4)
     }

--- a/PortfolioLedger/Views/TradeEntry/ClosePositionView.swift
+++ b/PortfolioLedger/Views/TradeEntry/ClosePositionView.swift
@@ -136,6 +136,33 @@ struct ClosePositionView: View {
 
         let quantity = closeQuantity
 
+        if action == .assign {
+            // Assignment requires generating both an option close AND an equity trade.
+            // Use the position's averagePrice as the premium for computing effective equity price.
+            guard let underlyingSymbol = instrument.underlyingSymbol else { return }
+            let equityInstrument = dataStore.getOrCreateInstrument(symbol: underlyingSymbol)
+
+            let syntheticOptionTxn = Transaction(
+                instrumentId: position.instrumentId,
+                timestamp: closeTimestamp,
+                action: position.quantity < 0 ? .sellToOpen : .buyToOpen,
+                quantity: quantity,
+                price: position.averagePrice,
+                fees: 0
+            )
+
+            guard let generated = try? LedgerEngine.generateAssignmentTransactions(
+                optionTransaction: syntheticOptionTxn,
+                instrument: instrument,
+                assignmentDate: closeTimestamp,
+                equityInstrument: equityInstrument
+            ) else { return }
+
+            dataStore.addTransactions([generated.optionClose, generated.equityTrade])
+            dismiss()
+            return
+        }
+
         let transaction = Transaction(
             instrumentId: position.instrumentId,
             timestamp: closeTimestamp,

--- a/PortfolioLedger/Views/TransactionsView.swift
+++ b/PortfolioLedger/Views/TransactionsView.swift
@@ -4,6 +4,9 @@ struct TransactionsView: View {
     @EnvironmentObject var dataStore: DataStore
     @State private var searchText = ""
     @State private var filterSymbol: String?
+    @State private var showingLinkedDeleteAlert = false
+    @State private var pendingDeleteTransactions: [Transaction] = []
+    @State private var pendingLinkedTransactions: [Transaction] = []
 
     private var allTransactions: [Transaction] {
         dataStore.transactions + dataStore.ledgerOutput.syntheticTransactions
@@ -104,6 +107,17 @@ struct TransactionsView: View {
             }
             .searchable(text: $searchText, prompt: "Search notes or tags")
             .navigationTitle("Ledger")
+            .alert("Delete Assignment", isPresented: $showingLinkedDeleteAlert) {
+                Button("Delete Both", role: .destructive) {
+                    dataStore.deleteTransactions(pendingDeleteTransactions + pendingLinkedTransactions)
+                }
+                Button("Cancel", role: .cancel) { }
+            } message: {
+                let names = pendingLinkedTransactions
+                    .compactMap { dataStore.instruments[$0.instrumentId]?.displayName }
+                    .joined(separator: ", ")
+                Text("This transaction is linked to an option assignment. Deleting it will also delete \(names.isEmpty ? "a linked transaction" : names). This cannot be undone.")
+            }
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Menu {
@@ -127,12 +141,14 @@ struct TransactionsView: View {
     private func deleteTransactions(at offsets: IndexSet) {
         for index in offsets {
             let row = ledgerRows[index]
-            if row.isOptionGroup || row.isEquityGroup {
-                for txn in row.transactions {
-                    dataStore.deleteTransaction(txn)
-                }
-            } else if let transaction = row.transaction {
-                dataStore.deleteTransaction(transaction)
+            let rowTxns = row.isOptionGroup || row.isEquityGroup ? row.transactions : [row.transaction].compactMap { $0 }
+            let linked = dataStore.linkedAssignmentTransactions(for: rowTxns)
+            if !linked.isEmpty {
+                pendingDeleteTransactions = rowTxns
+                pendingLinkedTransactions = linked
+                showingLinkedDeleteAlert = true
+            } else {
+                dataStore.deleteTransactions(rowTxns)
             }
         }
     }
@@ -203,58 +219,74 @@ struct TransactionDetailRow: View {
                     .frame(maxWidth: .infinity, alignment: .center)
                 }
             } else {
-                // Non-equity: instrument name then option details
-                if let inst = row.instrument {
-                    Text(inst.displayName).font(.headline).fontWeight(.bold)
+                if row.isOptionGroup {
+                    // Title + P/L on same top row (mirrors equity layout)
+                    HStack(alignment: .firstTextBaseline) {
+                        Text(row.instrument?.displayName ?? "Unknown Instrument")
+                            .font(.headline).fontWeight(.bold)
+                        Spacer()
+                        if !row.realizedPLs.isEmpty {
+                            Text("P/L")
+                                .font(.subheadline).foregroundColor(.secondary)
+                            Text(formatCurrency(optionTotalPL))
+                                .font(.body).fontWeight(.bold)
+                                .foregroundColor(optionTotalPL >= 0 ? .green : .red)
+                                .lineLimit(1).minimumScaleFactor(0.7)
+                        }
+                    }
                 } else {
-                    Text("Unknown Instrument").font(.headline).foregroundColor(.secondary)
+                    // Non-option single rows
+                    if let inst = row.instrument {
+                        Text(inst.displayName).font(.headline).fontWeight(.bold)
+                    } else {
+                        Text("Unknown Instrument").font(.headline).foregroundColor(.secondary)
+                    }
                 }
 
                 if row.isOptionGroup {
-                    HStack {
-                        Text("Qty:")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-                        Text(optionQuantity.asQuantity)
-                            .font(.subheadline)
-                            .fontWeight(.medium)
 
-                        Spacer()
-
-                        Text("\(openLabel):")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-                        Text("$\(formatPrice(optionOpenPrice))")
-                            .font(.subheadline)
-                            .fontWeight(.medium)
-
-                        Spacer()
-
-                        if hasClosing {
-                            Text("\(closeLabel):")
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-                            Text("$\(formatPrice(optionClosePrice))")
-                                .font(.subheadline)
-                                .fontWeight(.medium)
-                        } else {
-                            Text("Close:")
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-                            Text("—")
-                                .font(.subheadline)
-                                .fontWeight(.medium)
+                    // Qty | Open | Close columns
+                    HStack(alignment: .top, spacing: 0) {
+                        // Qty
+                        VStack(alignment: .leading, spacing: 0) {
+                            Text(" ").font(.caption)
+                            Spacer().frame(height: 4)
+                            Text("Qty").font(.subheadline).foregroundColor(.secondary)
+                            Text(optionQuantity.asQuantity).font(.body).fontWeight(.semibold)
                         }
-                    }
+                        .frame(width: 50, alignment: .leading)
 
-                    HStack {
-                        Text("P/L:")
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-                        Text(formatCurrency(optionTotalPL))
-                            .font(.subheadline)
-                            .fontWeight(.bold)
-                            .foregroundColor(optionTotalPL >= 0 ? .green : .red)
+                        // Open column (STO / BTO)
+                        VStack(alignment: .center, spacing: 0) {
+                            if let d = row.openingTransactions.first?.timestamp {
+                                Text(d, format: .dateTime.month(.abbreviated).day())
+                                    .font(.caption).foregroundColor(.secondary)
+                            } else {
+                                Text(" ").font(.caption)
+                            }
+                            Spacer().frame(height: 4)
+                            Text(openLabel).font(.subheadline).foregroundColor(openActionColor)
+                            Text("$\(formatPrice(optionOpenPrice))").font(.body).fontWeight(.medium)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .center)
+
+                        // Close column (BTC / STC / ASSIGN / EXPIRE)
+                        VStack(alignment: .center, spacing: 0) {
+                            if let d = row.closingTransactions.first?.timestamp {
+                                Text(d, format: .dateTime.month(.abbreviated).day())
+                                    .font(.caption).foregroundColor(.secondary)
+                            } else {
+                                Text(" ").font(.caption)
+                            }
+                            Spacer().frame(height: 4)
+                            if hasClosing {
+                                Text(closeLabel).font(.subheadline).foregroundColor(closeActionColor)
+                                Text("$\(formatPrice(optionClosePrice))").font(.body).fontWeight(.medium)
+                            } else {
+                                Text("—").font(.subheadline).foregroundColor(.secondary)
+                            }
+                        }
+                        .frame(maxWidth: .infinity, alignment: .center)
                     }
                 }
             }
@@ -341,7 +373,7 @@ struct TransactionDetailRow: View {
     }
 
     private var closeLabel: String {
-        if row.closingTransactions.contains(where: { $0.action == .assign }) { return "ASSIGN" }
+        if row.closingTransactions.contains(where: { $0.action == .assign || $0.flags.consumedByAssignment }) { return "ASSIGN" }
         if row.closingTransactions.contains(where: { $0.action == .expire }) { return "EXPIRE" }
         return row.closingTransactions.contains { $0.action == .buyToClose } ? "BTC" : "STC"
     }
@@ -405,6 +437,18 @@ struct TransactionDetailRow: View {
 
     private var optionTotalPL: Decimal {
         row.realizedPLs.reduce(0) { $0 + $1.realizedPL }
+    }
+
+    private var openActionColor: Color {
+        let isSell = row.openingTransactions.contains { $0.action == .sellToOpen }
+        return isSell ? Color(red: 0.00, green: 0.38, blue: 0.10) : Color(red: 0.55, green: 0.10, blue: 0.15)
+    }
+
+    private var closeActionColor: Color {
+        if row.closingTransactions.contains(where: { $0.action == .assign || $0.flags.consumedByAssignment }) { return .purple }
+        if row.closingTransactions.contains(where: { $0.action == .expire }) { return .gray }
+        let isBuy = row.closingTransactions.contains { $0.action == .buyToClose }
+        return isBuy ? Color(red: 0.55, green: 0.10, blue: 0.15) : Color(red: 0.00, green: 0.38, blue: 0.10)
     }
 
     private func weightedAveragePrice(for txns: [Transaction]) -> Decimal {

--- a/PortfolioLedger/Views/TransactionsView.swift
+++ b/PortfolioLedger/Views/TransactionsView.swift
@@ -141,7 +141,16 @@ struct TransactionsView: View {
     private func deleteTransactions(at offsets: IndexSet) {
         for index in offsets {
             let row = ledgerRows[index]
-            let rowTxns = row.isOptionGroup || row.isEquityGroup ? row.transactions : [row.transaction].compactMap { $0 }
+
+            // Open-remainder rows are residual shares of a partially-consumed lot —
+            // there is no standalone transaction for just those shares, so they
+            // cannot be deleted independently. Skip silently.
+            if row.quantityOverride != nil { continue }
+
+            let rowTxns = row.isOptionGroup || row.isEquityGroup
+                ? row.transactions
+                : [row.transaction].compactMap { $0 }
+
             let linked = dataStore.linkedAssignmentTransactions(for: rowTxns)
             if !linked.isEmpty {
                 pendingDeleteTransactions = rowTxns


### PR DESCRIPTION
Deletion / Data integrity
- Block delete on partial-lot remainders
- Deleting equity lot also deletes linked option (STO + BTC)
- Fix SwiftUI alert state (separate bool vs data)
- Add batch delete + linked lookup helpers

Options / Assignment flow
- Assign (ITM) now creates both option close + equity trade
- Use strike price only (no premium double-count)
- Fix BTC label for assigned options
- Add delete warning for linked option position

UI / Ledger
- Align option row layout with equity row
- Fix delete confirmation state bug
- Color-code open position cost (+/-, green/red)